### PR TITLE
goreleaser: before hookをシェルスクリプトとして分離する

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@
 version: 1
 before:
   hooks:
-    - go mod tidy
+    - bash scripts/release/goreleaser/before_hook.sh
 builds:
   - env:
       - CGO_ENABLED=0

--- a/scripts/release/goreleaser/before_hook.sh
+++ b/scripts/release/goreleaser/before_hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+go mod tidy


### PR DESCRIPTION
goreleaserのbefore hookにshellcheckがかかるようにシェルスクリプトとして分離します。