### PR TITLE
CI release: トークン発行時に対象リポジトリを指定する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: "homebrew-tap"
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
       - name: Run GoReleaser


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/actions/runs/7846579033/job/21413603037

```
  ⨯ release failed after 2m27s               error=1 error occurred:
	* homebrew tap formula: could not update "tfrbac.rb": PUT https://api.github.com/repos/dev-hato/homebrew-tap/contents/tfrbac.rb: 403 Resource not accessible by integration []
```

GitHub Appのトークン発行時に対象リポジトリを指定します。