### PR TITLE
newlineの対処

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 on:
   pull_request:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: false
           check-latest: true
         id: go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: test
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
     branches:
       - main
 jobs:
@@ -32,11 +27,5 @@ jobs:
             ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
             ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-${{ steps.go.outputs.go-version }}-
             ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-
-      - name: Ensure go.mod is tidied
-        run: go mod tidy
-      - uses: dev-hato/actions-diff-pr-management@cc201e3df74a342983025c4e97b7216b4e77f9f1 # v2.0.0
-        with:
-          github-token: ${{ steps.get-token.outputs.token }}
-          branch-name-prefix: fix-go-mod
       - name: go test
         run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+          check-latest: true
+        id: go
+      - name: go cache restore
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-${{ steps.go.outputs.go-version }}-${{ github.sha }}
+            ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-${{ steps.go.outputs.go-version }}-
+            ${{ env.GO-CACHE-VERSION }}-go-cache-${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/go.sum') }}-
+      - name: Ensure go.mod is tidied
+        run: go mod tidy
+      - uses: dev-hato/actions-diff-pr-management@cc201e3df74a342983025c4e97b7216b4e77f9f1 # v2.0.0
+        with:
+          github-token: ${{ steps.get-token.outputs.token }}
+          branch-name-prefix: fix-go-mod
+      - name: go test
+        run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.6
 require (
 	github.com/cockroachdb/errors v1.11.3
 	github.com/hashicorp/hcl/v2 v2.23.0
+	github.com/stretchr/testify v1.8.2
 )
 
 require (
@@ -13,6 +14,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -20,10 +22,12 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/zclconf/go-cty v1.13.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/dev-hato/tfrbac
 
-go 1.21
-
-toolchain go1.23.6
+go 1.23.6
 
 require (
 	github.com/cockroachdb/errors v1.11.3

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9D
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
@@ -42,6 +43,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -85,5 +91,9 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func tfrbac(body *hclwrite.Body) hclwrite.Tokens {
 	}
 	tokens := body.BuildTokens(nil)
 	ret := make(hclwrite.Tokens, 0, len(tokens))
+	startTokenPos := 0
 	for i := 0; i < len(tokens); i++ {
 		if len(deleteTokens) > 0 {
 			deleteToken := deleteTokens[0]
@@ -75,15 +76,21 @@ func tfrbac(body *hclwrite.Body) hclwrite.Tokens {
 				}
 			}
 			if find {
+				endTokenPos := i
 				i += len(deleteToken) - 1
 				if i+1 < len(tokens) && tokens[i+1].Type == hclsyntax.TokenNewline {
 					i++
+				} else if endTokenPos-1 > 0 && tokens[endTokenPos-1].Type == hclsyntax.TokenNewline {
+					endTokenPos--
 				}
 				deleteTokens = deleteTokens[1:]
+
+				ret = tokens[startTokenPos:endTokenPos].BuildTokens(ret)
+				startTokenPos = i + 1
 				continue
 			}
 		}
-		ret = tokens[i : i+1].BuildTokens(ret)
 	}
+	ret = tokens[startTokenPos:].BuildTokens(ret)
 	return ret
 }

--- a/main.go
+++ b/main.go
@@ -66,32 +66,34 @@ func tfrbac(body *hclwrite.Body) hclwrite.Tokens {
 	ret := make(hclwrite.Tokens, 0, len(tokens))
 	startTokenPos := 0
 	for i := 0; i < len(tokens); i++ {
-		if len(deleteTokens) > 0 {
-			deleteToken := deleteTokens[0]
-			find := true
-			for j := 0; j < len(deleteToken) && i+j < len(tokens); j++ {
-				if deleteToken[j] != tokens[i+j] {
-					find = false
-					break
-				}
-			}
-			if find {
-				endTokenPos := i
-				i += len(deleteToken) - 1
-				if i+1 < len(tokens) && tokens[i+1].Type == hclsyntax.TokenNewline {
-					i++ // 後ろに改行がある場合はそれを削除
-				} else if endTokenPos-2 > startTokenPos &&
-					tokens[endTokenPos-1].Type == hclsyntax.TokenNewline &&
-					tokens[endTokenPos-2].Type == hclsyntax.TokenNewline {
-					endTokenPos-- // 後ろに改行はないけど、上に二つ以上改行がある場合、一つ削除
-				}
-				deleteTokens = deleteTokens[1:]
-
-				ret = tokens[startTokenPos:endTokenPos].BuildTokens(ret)
-				startTokenPos = i + 1
-				continue
+		if len(deleteTokens) == 0 {
+			break
+		}
+		deleteToken := deleteTokens[0]
+		find := true
+		for j := 0; j < len(deleteToken) && i+j < len(tokens); j++ {
+			if deleteToken[j] != tokens[i+j] {
+				find = false
+				break
 			}
 		}
+		if !find {
+			continue
+		}
+
+		endTokenPos := i
+		i += len(deleteToken) - 1
+		if i+1 < len(tokens) && tokens[i+1].Type == hclsyntax.TokenNewline {
+			i++ // 後ろに改行がある場合はそれを削除
+		} else if endTokenPos-2 > startTokenPos &&
+			tokens[endTokenPos-1].Type == hclsyntax.TokenNewline &&
+			tokens[endTokenPos-2].Type == hclsyntax.TokenNewline {
+			endTokenPos-- // 後ろに改行はないけど、上に二つ以上改行がある場合、一つ削除
+		}
+		deleteTokens = deleteTokens[1:]
+
+		ret = tokens[startTokenPos:endTokenPos].BuildTokens(ret)
+		startTokenPos = i + 1
 	}
 	ret = tokens[startTokenPos:].BuildTokens(ret)
 	return ret

--- a/main.go
+++ b/main.go
@@ -79,9 +79,11 @@ func tfrbac(body *hclwrite.Body) hclwrite.Tokens {
 				endTokenPos := i
 				i += len(deleteToken) - 1
 				if i+1 < len(tokens) && tokens[i+1].Type == hclsyntax.TokenNewline {
-					i++
-				} else if endTokenPos-1 > 0 && tokens[endTokenPos-1].Type == hclsyntax.TokenNewline {
-					endTokenPos--
+					i++ // 後ろに改行がある場合はそれを削除
+				} else if endTokenPos-2 > startTokenPos &&
+					tokens[endTokenPos-1].Type == hclsyntax.TokenNewline &&
+					tokens[endTokenPos-2].Type == hclsyntax.TokenNewline {
+					endTokenPos-- // 後ろに改行はないけど、上に二つ以上改行がある場合、一つ削除
 				}
 				deleteTokens = deleteTokens[1:]
 

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func Test_tfrbac(t *testing.T) {
 			},
 			expected: nil,
 		},
-		"simple-1": { // MEMO: これはもう一行削ってもいいかもしれない
+		"simple-1": {
 			args: args{
 				input: []byte(
 					`
@@ -37,10 +37,10 @@ moved {
 }
 `),
 			},
-			expected: []byte(`
+			expected: []byte(
+				`
 resource "AAA" "aaa" {
 }
-
 `),
 		},
 		"simple-2": {
@@ -56,7 +56,8 @@ resource "AAA" "aaa" {
 }
 `),
 			},
-			expected: []byte(`
+			expected: []byte(
+				`
 resource "AAA" "aaa" {
 }
 `),
@@ -76,7 +77,8 @@ moved {
 }
 `),
 			},
-			expected: []byte(`
+			expected: []byte(
+				`
 `),
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_tfrbac(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		input []byte
+	}
+	tests := map[string]struct {
+		args     args
+		expected []byte
+	}{
+		"empty": {
+			args: args{
+				input: []byte(""),
+			},
+			expected: nil,
+		},
+		"simple-1": { // MEMO: これはもう一行削ってもいいかもしれない
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+`),
+			},
+			expected: []byte(`
+resource "AAA" "aaa" {
+}
+
+`),
+		},
+		"simple-2": {
+			args: args{
+				input: []byte(
+					`
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+
+resource "AAA" "aaa" {
+}
+`),
+			},
+			expected: []byte(`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"multiple-1": {
+			args: args{
+				input: []byte(
+					`
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+
+moved {
+  from = "XXX"
+  to = "YYY"
+}
+`),
+			},
+			expected: []byte(`
+`),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			file, diags := hclwrite.ParseConfig(tt.args.input, "", hcl.InitialPos)
+			if diags.HasErrors() {
+				require.Fail(t, diags.Error())
+			}
+			actual := tfrbac(file.Body())
+			require.Equal(t, tt.expected, actual.Bytes())
+		})
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -90,7 +90,7 @@ moved {
 				require.Fail(t, diags.Error())
 			}
 			actual := tfrbac(file.Body())
-			require.Equal(t, tt.expected, actual.Bytes())
+			require.Equal(t, string(tt.expected), string(actual.Bytes()))
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func Test_tfrbac(t *testing.T) {
 			},
 			expected: nil,
 		},
-		"simple-1": {
+		"simple-1-1": {
 			args: args{
 				input: []byte(
 					`
@@ -43,7 +43,25 @@ resource "AAA" "aaa" {
 }
 `),
 		},
-		"simple-2": {
+		"simple-1-2": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+`),
+			},
+			expected: []byte(
+				`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"simple-2-1": {
 			args: args{
 				input: []byte(
 					`
@@ -52,6 +70,24 @@ moved {
   to = "yyy"
 }
 
+resource "AAA" "aaa" {
+}
+`),
+			},
+			expected: []byte(
+				`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"simple-2-2": {
+			args: args{
+				input: []byte(
+					`
+moved {
+  from = "xxx"
+  to = "yyy"
+}
 resource "AAA" "aaa" {
 }
 `),
@@ -71,6 +107,24 @@ moved {
   to = "yyy"
 }
 
+moved {
+  from = "XXX"
+  to = "YYY"
+}
+`),
+			},
+			expected: []byte(
+				`
+`),
+		},
+		"multiple-2": {
+			args: args{
+				input: []byte(
+					`
+moved {
+  from = "xxx"
+  to = "yyy"
+}
 moved {
   from = "XXX"
   to = "YYY"

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_tfrbac(t *testing.T) {


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/issues/249
の対処

今までは、blockごとに消していたが、blockだと、 `{` の行と `}` の行に挟まれたものが消える(厳密にいうと正確には違うが)が、これだと、消したいブロックの一行上の行と一行下の行が両方残る。
もちろんこれが両方ブロックである
```
blockA {
}
deleteBlock {
}
blockB {
}
```
みたいな例だと問題ないが、
```
blockA {
}

deleteBlock {
}

blockB {
}
```
だと
```
blockA {
}


blockB {
}
```
と間に二行になってしまう。
一行にしたいので、blockの一つ下の行が空行であれば、それも含めて消したい。

blockを消す方針だと、前述の通り `{` の行と `}` の行に挟まれたものがblockとして判定され、さらに消されたあとだとどこが消された場所かわからなくなってしまうため、blockを消すのではなく、blockのtokensを取得しておく。
そして、次のフェーズで、消すtokensを探し、一致すればそのtokensを消す。
さらに、見つけたtokensの一つ次のtokenがnewlineであれば、それも消す対象のtokenとしておく。

こうすることで、消したいブロックを消し、さらに一行下がnewlineだった場合も消す、newlineじゃなければ何もしない、が実現できる。

(あってるのかなぁ？手元で何個かテストした感じは大丈夫そうだけど。てかテスト書きたい。)