### PR TITLE
CI test: merge queueでも動かす

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
マージするにはCI `test` が通ることが必須になっているため、merge queueでもこのCIを動かすようにします。