### PR TITLE
goreleaserのバージョンをsuper-linterに合わせる

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,14 +8,24 @@ on:
       - reopened
       - closed
   merge_group:
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1.11.5
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
+          token: ${{steps.generate_token.outputs.token}}
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -23,10 +33,10 @@ jobs:
         with:
           go-version: stable
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        run: go mod tidy
+        run: bash "${GITHUB_WORKSPACE}/scripts/format/format/format.sh"
       - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
           branch-name-prefix: format
           pr-title-prefix: Format修正
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: latest
+          version: v2.7.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/format/format/format.sh
+++ b/scripts/format/format/format.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+go mod tidy
+tag_name="$(yq '.jobs.super-linter.steps[-1].uses' .github/workflows/super-linter.yml | sed -e 's;/slim@.*;:slim;g')"
+tag_version="$(yq '.jobs.super-linter.steps[-1].uses | line_comment' .github/workflows/super-linter.yml)"
+version="$(docker run --rm --entrypoint '' "ghcr.io/${tag_name}-${tag_version}" /bin/sh -c 'goreleaser -v' | grep GitVersion | sed -e 's/GitVersion: *//g')"
+yq -i ".jobs.goreleaser.steps[-1].with.version|=\"v$version\"" .github/workflows/release.yml


### PR DESCRIPTION
goreleaserのバージョンがsuper-linterと実際で異なると、バリデーション周りでややこしいことになりそうなので (バリデーションは通るのに実際にはエラーやWarningが出る、あるいは、その逆)、CI `format` を使ってgoreleaserのバージョンをsuper-linterに合わせます。