### PR TITLE
CI format: PR close時にエラーにならないよう修正

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,6 +15,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      # jscpd:ignore-start
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1.11.5
@@ -27,6 +28,7 @@ jobs:
           token: ${{steps.generate_token.outputs.token}}
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      # jscpd:ignore-end
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1.11.5
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/actions/runs/13596247464/job/38013704446

CI `format` にてPR close時にエラーにならないように `Generate a token` stepを常に実行するようにします。