### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
+          cache: false
       - name: Get current tag
         id: get_current_tag
         run: echo "current_tag=$(git describe --tags --exact-match 2> /dev/null)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: v2.11.0
+          version: v2.11.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Super-Linter
-        uses: super-linter/super-linter/slim@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
+        uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.27.2
+    rev: v8.28.0
     hooks:
       - id: gitleaks


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/pull/333 をベースにsuper-linterをアップデートします。

https://github.com/dev-hato/tfrbac/actions/runs/17134823781/job/48608054419#step:4:176

```
  error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
    --> /github/workspace/.github/workflows/release.yml:40:9
     |
  20 |         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
  21 |         with:
  ...
  39 |       - name: Run GoReleaser
  40 |         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ runtime artifacts usually published here
     |
     = note: audit confidence → Low
     = note: this finding has an auto-fix
```

上記を修正するため、CI `goreleaser` のキャッシュを無効化しています。