### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -17,8 +17,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: dev-hato/actions-add-to-projects@4f20d0bdaeabd4b7728bbea294e2c5264c082611 # v0.0.109
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -25,8 +25,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: dev-hato/actions-format-json-yml@e26bb75bab9841682281db76bb3f11b9f29a29f0 # v0.0.100
         with:
           github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: dev-hato/actions-diff-pr-management@5cd3792bc98beed11cda90898bc81af6bfa199af # v2.2.5
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
           owner: ${{ github.repository_owner }}
           repositories: "homebrew-tap"
       # More assembly might be required: Docker logins, GPG, etc.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: v2.13.3
+          version: v2.15.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Super-Linter
-        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: write
   statuses: write
 jobs:
   super-linter:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.30.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dev-hato/tfrbac
 
-go 1.23.6
+go 1.24
 
 require (
 	github.com/cockroachdb/errors v1.12.0

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func run() (err error) {
 	}
 	defer func(root *os.Root) {
 		if closeErr := root.Close(); closeErr != nil {
-			err = errors.Join(err, errors.Wrap(closeErr, "Error on root.Close"))
+			err = errors.Join(err, errors.Wrap(closeErr, "Error on Close"))
 		}
 	}(root)
 
@@ -67,7 +67,7 @@ func run() (err error) {
 
 		wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC, info.Mode())
 		if err != nil {
-			return errors.Wrap(err, "Error on root.OpenFile")
+			return errors.Wrap(err, "Error on OpenFile")
 		}
 		defer func(wf *os.File) {
 			if closeErr := wf.Close(); closeErr != nil {
@@ -76,7 +76,7 @@ func run() (err error) {
 		}(wf)
 
 		if _, err = wf.Write(ret.Bytes()); err != nil {
-			return errors.Wrap(err, "Error on wf.Write")
+			return errors.Wrap(err, "Error on Write")
 		}
 
 		return nil
@@ -92,7 +92,7 @@ func run() (err error) {
 func readTFFile(root *os.Root, relPath string) (src []byte, err error) {
 	rf, err := root.Open(relPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error on root.Open")
+		return nil, errors.Wrap(err, "Error on Open")
 	}
 	defer func(rf *os.File) {
 		if closeErr := rf.Close(); closeErr != nil {

--- a/main.go
+++ b/main.go
@@ -19,15 +19,21 @@ func getRefactoringBlocks() []string {
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatalf("Error on run: %+v\n", err)
+	}
+}
+
+func run() (err error) {
 	const terraformDir = "./" //TODO: あとで引数で弄れるようにしたい
 
 	root, err := os.OpenRoot(terraformDir)
 	if err != nil {
-		log.Fatalf("Error on os.OpenRoot: %+v\n", err)
+		return errors.Wrap(err, "Error on os.OpenRoot")
 	}
 	defer func(root *os.Root) {
-		if err := root.Close(); err != nil {
-			log.Fatalf("Error on Close: %+v\n", err)
+		if closeErr := root.Close(); closeErr != nil {
+			err = errors.Join(err, errors.Wrap(closeErr, "Error on root.Close"))
 		}
 	}(root)
 
@@ -77,8 +83,10 @@ func main() {
 	})
 
 	if err != nil {
-		log.Fatalf("Error walking through Terraform directory: %+v\n", err)
+		return errors.Wrap(err, "Error walking through Terraform directory")
 	}
+
+	return nil
 }
 
 func readTFFile(root *os.Root, relPath string) (src []byte, err error) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -20,9 +21,19 @@ func getRefactoringBlocks() []string {
 func main() {
 	const terraformDir = "./" //TODO: あとで引数で弄れるようにしたい
 
-	err := filepath.Walk(terraformDir, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return errors.Wrap(err, "Error on filepath.Walk")
+	root, err := os.OpenRoot(terraformDir)
+	if err != nil {
+		log.Fatalf("Error on os.OpenRoot: %+v\n", err)
+	}
+	defer func(root *os.Root) {
+		if err := root.Close(); err != nil {
+			log.Fatalf("Error on Close: %+v\n", err)
+		}
+	}(root)
+
+	err = filepath.Walk(terraformDir, func(filePath string, info os.FileInfo, walkErr error) (err error) {
+		if walkErr != nil {
+			return errors.Wrap(walkErr, "Error on filepath.Walk")
 		}
 
 		// '.tf' 拡張子でなければスキップ
@@ -30,9 +41,14 @@ func main() {
 			return nil
 		}
 
-		src, err := os.ReadFile(filePath)
+		relPath, err := filepath.Rel(terraformDir, filePath)
 		if err != nil {
-			return errors.Wrap(err, "Error on os.ReadFile")
+			return errors.Wrap(err, "Error on filepath.Rel")
+		}
+
+		src, err := readTFFile(root, relPath)
+		if err != nil {
+			return errors.Wrap(err, "Error on readTFFile")
 		}
 
 		file, diags := hclwrite.ParseConfig(src, filePath, hcl.InitialPos)
@@ -43,8 +59,18 @@ func main() {
 		body := file.Body()
 		ret := tfrbac(body)
 
-		if err = os.WriteFile(filePath, ret.Bytes(), info.Mode()); err != nil {
-			return errors.Wrap(err, "Error on os.WriteFile")
+		wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC, info.Mode())
+		if err != nil {
+			return errors.Wrap(err, "Error on root.OpenFile")
+		}
+		defer func(wf *os.File) {
+			if closeErr := wf.Close(); closeErr != nil {
+				err = errors.Join(err, errors.Wrap(closeErr, "Error on Close"))
+			}
+		}(wf)
+
+		if _, err = wf.Write(ret.Bytes()); err != nil {
+			return errors.Wrap(err, "Error on wf.Write")
 		}
 
 		return nil
@@ -53,6 +79,25 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error walking through Terraform directory: %+v\n", err)
 	}
+}
+
+func readTFFile(root *os.Root, relPath string) (src []byte, err error) {
+	rf, err := root.Open(relPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error on root.Open")
+	}
+	defer func(rf *os.File) {
+		if closeErr := rf.Close(); closeErr != nil {
+			err = errors.Join(err, errors.Wrap(closeErr, "Error on Close"))
+		}
+	}(rf)
+
+	src, err = io.ReadAll(rf)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error on io.ReadAll")
+	}
+
+	return src, nil
 }
 
 func tfrbac(body *hclwrite.Body) hclwrite.Tokens {


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/pull/451 をベースにsuper-linterをアップデートします。

## 対応内容

### zizmor `secrets-outside-env` 警告の修正

各ワークフローの `secrets.PROJECT_AUTOMATION_APP_ID` / `secrets.PROJECT_AUTOMATION_PRIVATE_KEY` 参照箇所に `# zizmor: ignore[secrets-outside-env]` を追加しました。

対象ファイル:
- `.github/workflows/add-to-task-list.yml`
- `.github/workflows/format-json-yml.yml`
- `.github/workflows/format.yml`
- `.github/workflows/release.yml`

https://docs.zizmor.sh/audits/#secrets-outside-env を見るとenvironmentにスコープを絞った方が良いという話でしたが、それをするとリポジトリを作るたびにシークレットを追加しないといけなくて面倒という話もあるので、無視 or environmentを作る、のどちらが良いか意見が欲しいです。

### gosec G122 / G703 の修正

Go 1.24 で追加された `os.Root` を使ってファイルの読み書きを行うよう変更しました。
これにより、シンボリックリンクの TOCTOU 競合（G122）とパストラバーサル（G703）の問題を根本解消しています。

あわせて `go.mod` を `go 1.24` に更新しました。

### super-linter への `pull-requests: write` 権限追加

GitHub API へのコメント投稿時に 403 エラーが発生していたため、`.github/workflows/super-linter.yml` に `pull-requests: write` を追加しました。

### `main()` を `run()` に切り出し

`log.Fatalf` は内部で `os.Exit` を呼ぶため、それによって `defer` がスキップされます。
この問題を解消するため、処理を `run()` 関数に切り出しました。