### PR TITLE
シンボリックリンクの扱いが変わったので、シンボリックリンクのファイルを読み込むとエラーになるようになった

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func run() (err error) {
 		body := file.Body()
 		ret := tfrbac(body)
 
-		wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC, info.Mode())
+		wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
 		if err != nil {
 			return errors.Wrap(err, "Error on OpenFile")
 		}


### PR DESCRIPTION
シンボリックリンクになっているtfファイルが読まれた時に、ここでエラーになっている