### PR TITLE
test: readTFFileとrunのI/Oテストを追加する

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -102,22 +102,6 @@ resource "AAA" "aaa" {
 }
 `),
 		},
-		"resource-with-moved-block-symlink-cross-dir-from-sym-link-dir": {
-			args: args{
-				input: []byte(
-					`
-resource "AAA" "aaa" {
-}
-
-moved {
-  from = "xxx"
-  to = "yyy"
-}
-`),
-				workingDir: "sym-link-dir",
-			},
-			setup: symlinkSetup,
-		},
 		"resource-without-refactoring-block": {
 			args: args{
 				input: []byte(

--- a/main_test.go
+++ b/main_test.go
@@ -42,20 +42,7 @@ resource "AAA" "aaa" {
 
 func Test_run(t *testing.T) {
 	type args struct {
-		input      []byte
-		workingDir string // 実行ディレクトリ (空文字 = tmpDir)
-	}
-
-	symlinkSetup := func(tmpDir string, dirName string, filename string) {
-		symLinkDir := filepath.Join(tmpDir, "sym-link-dir")
-
-		if err := os.Mkdir(symLinkDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := os.Symlink(filepath.Join("..", dirName, filename), filepath.Join(symLinkDir, filename)); err != nil {
-			t.Fatal(err)
-		}
+		input []byte
 	}
 
 	tests := map[string]struct {
@@ -95,7 +82,17 @@ moved {
   to = "yyy"
 }`),
 			},
-			setup: symlinkSetup,
+			setup: func(tmpDir string, dirName string, filename string) {
+				symLinkDir := filepath.Join(tmpDir, "sym-link-dir")
+
+				if err := os.Mkdir(symLinkDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+
+				if err := os.Symlink(filepath.Join("..", dirName, filename), filepath.Join(symLinkDir, filename)); err != nil {
+					t.Fatal(err)
+				}
+			},
 			expected: []byte(
 				`
 resource "AAA" "aaa" {
@@ -140,13 +137,7 @@ resource "AAA" "aaa" {
 				t.Fatal(err)
 			}
 
-			workingDir := tmpDir
-
-			if tt.args.workingDir != "" {
-				workingDir = filepath.Join(workingDir, tt.args.workingDir)
-			}
-
-			if err = os.Chdir(workingDir); err != nil {
+			if err = os.Chdir(tmpDir); err != nil {
 				t.Fatal(err)
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -35,9 +35,7 @@ resource "AAA" "aaa" {
 	}(root)
 
 	got, err := readTFFile(root, filename)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	require.Equal(t, input, got)
 }
@@ -135,9 +133,8 @@ resource "AAA" "aaa" {
 				}
 			})
 
-			if err = run(); err != nil {
-				t.Fatal(err)
-			}
+			err = run()
+			require.NoError(t, err)
 
 			got, err := os.ReadFile(filePath)
 			if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -118,27 +118,6 @@ moved {
 			},
 			setup: symlinkSetup,
 		},
-		"resource-with-moved-block-symlink-cross-dir-from-main-dir": {
-			args: args{
-				input: []byte(
-					`
-resource "AAA" "aaa" {
-}
-
-moved {
-  from = "xxx"
-  to = "yyy"
-}
-`),
-				workingDir: "main-dir",
-			},
-			setup: symlinkSetup,
-			expected: []byte(
-				`
-resource "AAA" "aaa" {
-}
-`),
-		},
 		"resource-without-refactoring-block": {
 			args: args{
 				input: []byte(

--- a/main_test.go
+++ b/main_test.go
@@ -64,7 +64,7 @@ moved {
 }
 `),
 			},
-			setup: func(tmpDir string, filename string) {},
+			setup: func(_ string, _ string) {},
 			expected: []byte(
 				`
 resource "AAA" "aaa" {
@@ -101,7 +101,7 @@ resource "AAA" "aaa" {
 resource "AAA" "aaa" {
 }`),
 			},
-			setup: func(tmpDir string, filename string) {},
+			setup: func(_ string, _ string) {},
 			expected: []byte(`
 resource "AAA" "aaa" {
 }`),

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,153 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_readTFFile(t *testing.T) {
+	t.Parallel()
+
+	filename := "resource_without_refactoring_block.tf"
+	input := []byte(
+		`
+resource "AAA" "aaa" {
+}`)
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, filename), input, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(root *os.Root) {
+		if closeErr := root.Close(); closeErr != nil {
+			t.Fatal(closeErr)
+		}
+	}(root)
+
+	got, err := readTFFile(root, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, input, got)
+}
+
+func Test_run(t *testing.T) {
+	type args struct {
+		input []byte
+	}
+	tests := map[string]struct {
+		args     args
+		setup    func(tmpDir string, filename string)
+		expected []byte
+	}{
+		"resource-with-moved-block": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+`),
+			},
+			setup: func(tmpDir string, filename string) {},
+			expected: []byte(
+				`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"resource-with-moved-block-symlink-target": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+
+moved {
+  from = "xxx"
+  to = "yyy"
+}`),
+			},
+			setup: func(tmpDir string, filename string) {
+				if err := os.Symlink(filename, filepath.Join(tmpDir, "link_"+filename)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			expected: []byte(
+				`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"resource-without-refactoring-block": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}`),
+			},
+			setup: func(tmpDir string, filename string) {},
+			expected: []byte(`
+resource "AAA" "aaa" {
+}`),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			filename := name + ".tf"
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, filename)
+
+			if err := os.WriteFile(filePath, tt.args.input, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			tt.setup(tmpDir, filename)
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err = os.Chdir(tmpDir); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				if chErr := os.Chdir(origDir); chErr != nil {
+					t.Fatal(chErr)
+				}
+			})
+
+			if err = run(); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.Equal(t, string(tt.expected), string(got))
+		})
+	}
+}
 
 func Test_tfrbac(t *testing.T) {
 	t.Parallel()

--- a/main_test.go
+++ b/main_test.go
@@ -42,11 +42,25 @@ resource "AAA" "aaa" {
 
 func Test_run(t *testing.T) {
 	type args struct {
-		input []byte
+		input      []byte
+		workingDir string // 実行ディレクトリ (空文字 = tmpDir)
 	}
+
+	symlinkSetup := func(tmpDir string, dirName string, filename string) {
+		symLinkDir := filepath.Join(tmpDir, "sym-link-dir")
+
+		if err := os.Mkdir(symLinkDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Symlink(filepath.Join("..", dirName, filename), filepath.Join(symLinkDir, filename)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	tests := map[string]struct {
 		args     args
-		setup    func(tmpDir string, filename string)
+		setup    func(tmpDir string, dirName string, filename string)
 		expected []byte
 	}{
 		"resource-with-moved-block": {
@@ -62,14 +76,14 @@ moved {
 }
 `),
 			},
-			setup: func(_ string, _ string) {},
+			setup: func(_ string, _ string, _ string) {},
 			expected: []byte(
 				`
 resource "AAA" "aaa" {
 }
 `),
 		},
-		"resource-with-moved-block-symlink-target": {
+		"resource-with-moved-block-symlink-cross-dir-from-tmpdir": {
 			args: args{
 				input: []byte(
 					`
@@ -81,11 +95,44 @@ moved {
   to = "yyy"
 }`),
 			},
-			setup: func(tmpDir string, filename string) {
-				if err := os.Symlink(filename, filepath.Join(tmpDir, "link_"+filename)); err != nil {
-					t.Fatal(err)
-				}
+			setup: symlinkSetup,
+			expected: []byte(
+				`
+resource "AAA" "aaa" {
+}
+`),
+		},
+		"resource-with-moved-block-symlink-cross-dir-from-sym-link-dir": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+`),
+				workingDir: "sym-link-dir",
 			},
+			setup: symlinkSetup,
+		},
+		"resource-with-moved-block-symlink-cross-dir-from-main-dir": {
+			args: args{
+				input: []byte(
+					`
+resource "AAA" "aaa" {
+}
+
+moved {
+  from = "xxx"
+  to = "yyy"
+}
+`),
+				workingDir: "main-dir",
+			},
+			setup: symlinkSetup,
 			expected: []byte(
 				`
 resource "AAA" "aaa" {
@@ -99,7 +146,7 @@ resource "AAA" "aaa" {
 resource "AAA" "aaa" {
 }`),
 			},
-			setup: func(_ string, _ string) {},
+			setup: func(_ string, _ string, _ string) {},
 			expected: []byte(`
 resource "AAA" "aaa" {
 }`),
@@ -110,20 +157,33 @@ resource "AAA" "aaa" {
 		t.Run(name, func(t *testing.T) {
 			filename := name + ".tf"
 			tmpDir := t.TempDir()
-			filePath := filepath.Join(tmpDir, filename)
+			dirName := "main-dir"
+			fileDir := filepath.Join(tmpDir, dirName)
+
+			if err := os.Mkdir(fileDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			filePath := filepath.Join(fileDir, filename)
 
 			if err := os.WriteFile(filePath, tt.args.input, 0644); err != nil {
 				t.Fatal(err)
 			}
 
-			tt.setup(tmpDir, filename)
+			tt.setup(tmpDir, dirName, filename)
 
 			origDir, err := os.Getwd()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if err = os.Chdir(tmpDir); err != nil {
+			workingDir := tmpDir
+
+			if tt.args.workingDir != "" {
+				workingDir = filepath.Join(workingDir, tt.args.workingDir)
+			}
+
+			if err = os.Chdir(workingDir); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
https://github.com/dev-hato/tfrbac/pull/459 のような不具合を防ぐため、 `readTFFile` と `run` のI/Oテストを追加します。
他に追加したいテストケースがあればレビューで指摘してもらうか、後で追加のPRを立ててもらえると。